### PR TITLE
DEBUG configuration should now build

### DIFF
--- a/code/engine.vc2008/3rd party/dxerr/dxerr2015.vcxproj
+++ b/code/engine.vc2008/3rd party/dxerr/dxerr2015.vcxproj
@@ -115,6 +115,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../../../sdk/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <ImportLibrary>..\..\..\..\libraries\$(Configuration)\$(ProjectName).lib</ImportLibrary>


### PR DESCRIPTION
dxerr2015 project: DEBUG Configuration - Code Generation flag set MultiThreadedDLL instead of default MultiThreadedDLL Debug. Now xrNetServer compiles without error in DEBUG.

As a side note, I noticed that R4 project has dxerr.lib as input, is this correct or should it be removed?