### PR TITLE
Fix in-game flickering

### DIFF
--- a/code/engine.vc2008/Layers/xrRender/HWCaps.cpp
+++ b/code/engine.vc2008/Layers/xrRender/HWCaps.cpp
@@ -72,12 +72,11 @@ u32 GetNVGpuNum()
 u32 GetATIGpuNum()
 {
 	int iGpuNum = AtiMultiGPUAdapters();
-	//int iGpuNum = 1;
+	
+	if (iGpuNum <= 0)
+		return 0;
 
-	if (iGpuNum>1)
-	{
-		Msg	("* ATI MGPU: %d-Way CrossFire detected.", iGpuNum);
-	}
+	Msg	("* ATI MGPU: %d-Way CrossFire detected.", iGpuNum);
 
 	return iGpuNum;
 }

--- a/code/engine.vc2008/Layers/xrRender/HWCaps.cpp
+++ b/code/engine.vc2008/Layers/xrRender/HWCaps.cpp
@@ -76,7 +76,8 @@ u32 GetATIGpuNum()
 	if (iGpuNum <= 0)
 		return 0;
 
-	Msg	("* ATI MGPU: %d-Way CrossFire detected.", iGpuNum);
+	if (iGPUNum > 1)
+		Msg	("* ATI MGPU: %d-Way CrossFire detected.", iGpuNum);
 
 	return iGpuNum;
 }


### PR DESCRIPTION
Resolves Issue: https://github.com/Im-dex/xray-162/issues/11

See commit: https://github.com/Im-dex/xray-162/pull/14/commits/8e0d9d7ffc369e0785fea03bf206d0c83424164b
Fix in-game flickering of screen caused by incorrect GPU count being detected due to u32 GetATIGpuNum() returning -1

Due to this, `res = std::max(1, -1);` caused res to equal -1 and `res = std::min(-1,8)` to return 8. I'd sure like to know why, as that is very odd behavior and wonder if there are other cases like this.