### PR TITLE
Allow build luajit project

### DIFF
--- a/code/3rd-party/luajit/CMakeLists.txt
+++ b/code/3rd-party/luajit/CMakeLists.txt
@@ -7,7 +7,7 @@ set(OUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/${ARCH_SUFFIX})
 
 file(WRITE ${OUT_DIR}/makeluajit.bat
            "call \"${VC_ENV_BAT}\" ${ARCH_SUFFIX}
-           cd ${SRC_DIR}
+           cd /d \"${SRC_DIR}\"
            call msvcbuild.bat
            del luajit.exe
            del lua51.exp")


### PR DESCRIPTION
Allow build luajit project, which located at drive other than C and in its path allow contain spaces